### PR TITLE
[fix]:firbaseConfigを修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.3",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "web-vitals": "^2.1.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -2,12 +2,12 @@ import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 
 const firebaseConfig = {
-  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
-  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGE_SENDER_ID,
-  appId: process.env.REACT_APP_FIREBASE_SENDER_ID,
+  apiKey: "AIzaSyCcibGlYwrQcnPBtaV-G_tfGL3POlxrrAo",
+  authDomain: "hackathon-vol3.firebaseapp.com",
+  projectId: "hackathon-vol3",
+  storageBucket: "hackathon-vol3.appspot.com",
+  messagingSenderId: "55955625369",
+  appId: "1:55955625369:web:6f1a4eb0a0de4a17856f08",
 };
 
 initializeApp(firebaseConfig);


### PR DESCRIPTION
firebaseのプロジェクトの設定から
// Import the functions you need from the SDKs you need
import { initializeApp } from "firebase/app";
// TODO: Add SDKs for Firebase products that you want to use
// https://firebase.google.com/docs/web/setup#available-libraries

// Your web app's Firebase configuration
const firebaseConfig = {
  apiKey: "AIzaSyCcibGlYwrQcnPBtaV-G_tfGL3POlxrrAo",
  authDomain: "hackathon-vol3.firebaseapp.com",
  projectId: "hackathon-vol3",
  storageBucket: "hackathon-vol3.appspot.com",
  messagingSenderId: "55955625369",
  appId: "1:55955625369:web:6f1a4eb0a0de4a17856f08"
};

// Initialize Firebase
const app = initializeApp(firebaseConfig);

をコピーし、firebase.jsを修正しました。まだ、少しコンソールログでエラーが表示されているのでそこは確認お願いします。